### PR TITLE
Minor formatting adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#NIWAData Mashup
+# NIWAData Mashup
 
 Welcome to the NIWAData Mashup repository.
 
-In this repository you can find a collection of scripts written in Python, R and VBA(for MS Excel) showing how to mashup
+In this repository you can find a collection of scripts written in Python, R and VBA (for MS Excel) showing how to mashup
 data from NIWAData.
 
-##What is NIWAData?
+## What is NIWAData?
 
 NIWAData gives instant access to current and historical climate data from NIWA’s network of over 300 monitoring stations located throughout the country, and over 11,000 ‘virtual’ climate stations located on a grid covering the entire New Zealand area.
 To get started, follow this link [NIWAData](https://data.niwa.co.nz).


### PR DESCRIPTION
GitHub changed its Markdown syntax some time ago. Besides needing a blank space between heading and paragraph, it now also needs a space before heading marker and the first character.